### PR TITLE
Array deque

### DIFF
--- a/src/main/java/com/github/javalbert/orm/BatchResolver.java
+++ b/src/main/java/com/github/javalbert/orm/BatchResolver.java
@@ -230,7 +230,9 @@ public class BatchResolver extends ObjectGraphResolver {
 			final GraphEntity relatedEntity = relationship.getRelatedEntity();
 			
 			if (entityColumnsMap.containsKey(relatedEntity)) {
-				logger.error(relatedEntity + " already handled and would have resulted in a circular dependency and a StackOverflowError. Create a new GraphEntity object with the same class but different alias.");
+				logger.error(relatedEntity + " already handled and would have resulted in a circular "
+						+ "dependency and a StackOverflowError. Create a new GraphEntity "
+						+ "object with the same class but different alias.");
 				return null;
 			}
 
@@ -706,9 +708,6 @@ public class BatchResolver extends ObjectGraphResolver {
 				switch (relationship.getFieldType()) {
 					case Relationship.FIELD_DEQUE:
 						relatedObjects = getCollections(connection, owners, CollectionUtils.FACTORY_DEQUE);
-						break;
-					case Relationship.FIELD_LINKED_LIST:
-						relatedObjects = getCollections(connection, owners, CollectionUtils.FACTORY_LINKED_LIST);
 						break;
 					case Relationship.FIELD_LINKED_MAP:
 						relatedObjects = getMaps(connection, owners, CollectionUtils.FACTORY_LINKED_MAP);

--- a/src/main/java/com/github/javalbert/orm/CartesianProductResolver.java
+++ b/src/main/java/com/github/javalbert/orm/CartesianProductResolver.java
@@ -729,9 +729,6 @@ public class CartesianProductResolver extends ObjectGraphResolver {
 				case Relationship.FIELD_DEQUE:
 					addToCollection(ownerColumns, owner, classColumns, object, CollectionUtils.FACTORY_DEQUE);
 					break;
-				case Relationship.FIELD_LINKED_LIST:
-					addToCollection(ownerColumns, owner, classColumns, object, CollectionUtils.FACTORY_LINKED_LIST);
-					break;
 				case Relationship.FIELD_LINKED_MAP:
 					addToMap(relationship, ownerColumns, owner, classColumns, object, CollectionUtils.FACTORY_LINKED_MAP);
 					break;

--- a/src/main/java/com/github/javalbert/orm/NPlusOneResolver.java
+++ b/src/main/java/com/github/javalbert/orm/NPlusOneResolver.java
@@ -476,9 +476,6 @@ public class NPlusOneResolver extends ObjectGraphResolver {
 					case Relationship.FIELD_DEQUE:
 						relatedObjects = getCollections(connection, owners, CollectionUtils.FACTORY_DEQUE);
 						break;
-					case Relationship.FIELD_LINKED_LIST:
-						relatedObjects = getCollections(connection, owners, CollectionUtils.FACTORY_LINKED_LIST);
-						break;
 					case Relationship.FIELD_LINKED_MAP:
 						relatedObjects = getMaps(connection, owners, CollectionUtils.FACTORY_LINKED_MAP);
 						break;

--- a/src/main/java/com/github/javalbert/orm/Relationship.java
+++ b/src/main/java/com/github/javalbert/orm/Relationship.java
@@ -25,14 +25,13 @@ import com.github.javalbert.sqlbuilder.SortType;
  */
 @SuppressWarnings({ "unchecked" })
 public class Relationship {
-	public static final int FIELD_DEQUE = 7;
-	public static final int FIELD_LINKED_LIST = 1;
+	public static final int FIELD_DEQUE = 1;
 	public static final int FIELD_LINKED_MAP = 2;
 	public static final int FIELD_LINKED_SET = 3;
 	public static final int FIELD_LIST = 4;
 	public static final int FIELD_MAP = 5;
 	public static final int FIELD_SET = 6;
-	public static final int FIELD_UNIQUE = 8;
+	public static final int FIELD_UNIQUE = 7;
 	
 	public static final int TYPE_N_TO_ONE = 1;
 	public static final int TYPE_ONE_TO_MANY = 2;
@@ -180,6 +179,17 @@ public class Relationship {
 			orderByColumns.add(new OrderByColumn(column, SortType.DESC));
 			return this;
 		}
+		
+		/**
+		 * 
+		 * @param fieldName corresponds to the value of @Related annotation in a field or property of owner class
+		 * @return
+		 */
+		public Builder inDeque(String fieldName) {
+			this.fieldName = fieldName;
+			fieldType = FIELD_DEQUE;
+			return this;
+		}
 
 		/**
 		 * 
@@ -189,17 +199,6 @@ public class Relationship {
 		public Builder inField(String fieldName) {
 			this.fieldName = fieldName;
 			fieldType = FIELD_UNIQUE;
-			return this;
-		}
-
-		/**
-		 * 
-		 * @param fieldName corresponds to the value of @Related annotation in a field or property of owner class
-		 * @return
-		 */
-		public Builder inLinkedList(String fieldName) {
-			this.fieldName = fieldName;
-			fieldType = FIELD_LINKED_LIST;
 			return this;
 		}
 
@@ -275,17 +274,6 @@ public class Relationship {
 		public Builder inSet(String fieldName) {
 			this.fieldName = fieldName;
 			fieldType = FIELD_SET;
-			return this;
-		}
-		
-		/**
-		 * 
-		 * @param fieldName corresponds to the value of @Related annotation in a field or property of owner class
-		 * @return
-		 */
-		public Builder inStack(String fieldName) {
-			this.fieldName = fieldName;
-			fieldType = FIELD_DEQUE;
 			return this;
 		}
 		

--- a/src/main/java/com/github/javalbert/utils/collections/CollectionUtils.java
+++ b/src/main/java/com/github/javalbert/utils/collections/CollectionUtils.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,11 +30,6 @@ public final class CollectionUtils {
 	public static final CollectionFactory FACTORY_DEQUE = new CollectionFactory() {
 		@Override
 		public <T> Collection<T> newInstance() { return new ArrayDeque<>(); }
-	};
-	
-	public static final CollectionFactory FACTORY_LINKED_LIST = new CollectionFactory() {
-		@Override
-		public <T> Collection<T> newInstance() { return new LinkedList<>(); }
 	};
 	
 	public static final MapFactory FACTORY_LINKED_MAP = new MapFactory() {

--- a/src/test/java/com/github/javalbert/domain/Customer.java
+++ b/src/test/java/com/github/javalbert/domain/Customer.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright 2017 Albert Shun-Dat Chan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ *******************************************************************************/
 package com.github.javalbert.domain;
 
 import java.util.List;

--- a/src/test/java/com/github/javalbert/domain/Order.java
+++ b/src/test/java/com/github/javalbert/domain/Order.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright 2017 Albert Shun-Dat Chan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ *******************************************************************************/
 package com.github.javalbert.domain;
 
 import java.math.BigDecimal;

--- a/src/test/java/com/github/javalbert/domain/Product.java
+++ b/src/test/java/com/github/javalbert/domain/Product.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright 2017 Albert Shun-Dat Chan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ *******************************************************************************/
 package com.github.javalbert.domain;
 
 import java.math.BigDecimal;

--- a/src/test/java/com/github/javalbert/domain/Store.java
+++ b/src/test/java/com/github/javalbert/domain/Store.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright 2017 Albert Shun-Dat Chan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ *******************************************************************************/
 package com.github.javalbert.domain;
 
 import java.util.Collection;


### PR DESCRIPTION
Although no Stack references were found, LinkedList is now completely removed from GraphEntity Relationships.

See http://stackoverflow.com/a/6129967. LinkedList has memory overhead.
See http://stackoverflow.com/a/12524949. Stack implements List interface and is itself not a interface.